### PR TITLE
Fix relative path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var sass = require("node-sass");
 var DtsCreator = require("typed-css-modules");
 var path = require("path");
 var fs = require("fs");
-var appRoot = require("app-root-path");
+var appRoot = require("app-root-path").path;
 var css2rn = require("css-to-react-native-transform").default;
 
 var creator = new DtsCreator();
@@ -79,7 +79,12 @@ function renderToCSS({ src, filename, options }) {
       const incPaths = importerOptions.includePaths.slice(0).split(":");
 
       if (urlPath.dir.length > 0) {
-        incPaths.unshift(path.resolve(path.dirname(filename), urlPath.dir)); // add the file's dir to the search array
+        // incPaths.map() does not work, I believe because node-sass is built off an old version of V8.
+        // The error is terrifying (FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal).
+        for (let i = 0; i < incPaths.length; i++) {
+          // Adjust the paths based on the path given.
+          incPaths[i] = path.resolve(incPaths[i], urlPath.dir);
+        }
       }
       const f = findVariant(urlPath.name, exts, incPaths);
 


### PR DESCRIPTION
Previously, this module was incorrectly resolving paths. For an import of `A/b` from file `/C/d.scss`, it was looking in **[`/C/A`, `/C`, `/`]** for a file `d.android.scss`/`d.ios.scss`, `d.native.scss`, `d.scss`.

For an import of `A/b` from file `/C/d.scss`, it now looks in **[`/C/A`, `/A`]** for a file `d.android.scss`/`d.ios.scss`, `d.native.scss`, `d.scss`.

This means that `@import 'styles/general'` from a file `my-project/component/header/styles.scss` no longer incorrectly resolves to `my-project/general.ios.scss` or `my-project/component/header/general.ios.scss`. It still resolves to `my-project/component/header/styles/general.ios.scss`, if it exists, but if that fails it now falls back to `my-project/styles/general.ios.scss`.

I have also submitted this PR to https://github.com/kristerkari/react-native-sass-transformer/pull/25.